### PR TITLE
fix: output error message

### DIFF
--- a/seismic_forward/__init__.py
+++ b/seismic_forward/__init__.py
@@ -1,4 +1,5 @@
 """Seismic Forward Modeling Package"""
+
 from .cli import main
 
 if __name__ == "__main__":

--- a/seismic_forward/cli.py
+++ b/seismic_forward/cli.py
@@ -2,7 +2,9 @@
 This module provides the command-line interface for running seismic-forward
 simulations.
 """
+
 import argparse
+
 import sys
 from typing import NoReturn
 from importlib.metadata import version, PackageNotFoundError
@@ -11,7 +13,7 @@ from .simulation import run_simulation, SeismicForwardError
 
 def get_version() -> str:
     """Get the version of the seismic-forward package.
-    
+
     Returns:
         str: The version string, or "unknown" if not available.
     """
@@ -23,7 +25,7 @@ def get_version() -> str:
 
 def main() -> NoReturn:
     """Main entry point for the CLI.
-    
+
     Returns:
         NoReturn: The function either exits successfully or with an error code.
     """
@@ -31,19 +33,13 @@ def main() -> NoReturn:
         prog="seismic_forward",
         description="Seismic Forward Modeling Tool - Generate synthetic seismic from elastic parameters",
     )
+    parser.add_argument("modelfile", nargs="?", help="Path to the XML model file")
     parser.add_argument(
-        "modelfile",
-        nargs="?",
-        help="Path to the XML model file"
+        "--version", action="version", version=f"seismic_forward {get_version()}"
     )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"seismic_forward {get_version()}"
-    )
-    
+
     args = parser.parse_args()
-    
+
     if args.modelfile is None:
         parser.print_help()
         print("\nError: A modelfile must be provided.")
@@ -53,7 +49,7 @@ def main() -> NoReturn:
         run_simulation(args.modelfile, capture_output=False)
         sys.exit(0)
     except (SeismicForwardError, FileNotFoundError) as e:
-        print(f"Error: {e}")
+        print(f"Error message: {e}")
         sys.exit(1)
     except Exception as e:
         print(f"Unexpected error: {e}")
@@ -61,4 +57,4 @@ def main() -> NoReturn:
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/seismic_forward/cli.py
+++ b/seismic_forward/cli.py
@@ -49,7 +49,7 @@ def main() -> NoReturn:
         run_simulation(args.modelfile, capture_output=False)
         sys.exit(0)
     except (SeismicForwardError, FileNotFoundError) as e:
-        print(f"Error message: {e}")
+        print(f"Error: {e}")
         sys.exit(1)
     except Exception as e:
         print(f"Unexpected error: {e}")

--- a/seismic_forward/simulation.py
+++ b/seismic_forward/simulation.py
@@ -2,6 +2,7 @@
 This module provides the main Python API for running seismic-forward simulations.
 It handles the execution of the underlying C++ binary and manages simulation results.
 """
+
 from pathlib import Path
 import subprocess
 from typing import Union, Dict, Any
@@ -9,15 +10,16 @@ from typing import Union, Dict, Any
 
 class SeismicForwardError(Exception):
     """Base exception for seismic-forward errors."""
+
     pass
 
 
 def get_binary_path() -> str:
     """Get the path to the seismic-forward binary.
-    
+
     Returns:
         str: The absolute path to the seismic-forward binary.
-        
+
     Raises:
         FileNotFoundError: If the binary cannot be found in the expected location.
     """
@@ -34,22 +36,21 @@ def get_binary_path() -> str:
 
 
 def run_simulation(
-    model_file: Union[str, Path], 
-    capture_output: bool = True
+    model_file: Union[str, Path], capture_output: bool = True
 ) -> Dict[str, Any]:
     """Run a seismic-forward simulation.
-    
+
     Args:
         model_file: Path to the model file (string or Path object).
         capture_output: Whether to capture and return the simulation output.
             If False, output will be printed directly to stdout.
-            
+
     Returns:
         dict: A dictionary containing simulation results with keys:
             - 'success': bool indicating if simulation completed successfully
             - 'output': str containing stdout (if capture_output=True)
             - 'error': str containing stderr (if capture_output=True)
-            
+
     Raises:
         SeismicForwardError: If the simulation fails or encounters an error.
         FileNotFoundError: If the model file or binary cannot be found.
@@ -64,18 +65,19 @@ def run_simulation(
             [binary_path, str(model_path)],
             check=False,
             text=True,
-            capture_output=capture_output
+            capture_output=capture_output,
         )
 
         output = {
-            'success': result.returncode == 0,
-            'output': result.stdout if capture_output else None,
-            'error': result.stderr if capture_output else None
+            "success": result.returncode == 0,
+            "output": result.stdout if capture_output else None,
+            "error": result.stderr if capture_output else None,
         }
 
-        if not output['success']:
+        if not output["success"]:
             raise SeismicForwardError(
-                f"Simulation failed with return code {result.returncode}"
+                f"Seismic Forward failed with return code {result.returncode}\n"
+                f"Error message:\n {result.stderr}"
             )
 
         return output

--- a/seismic_forward/simulation.py
+++ b/seismic_forward/simulation.py
@@ -44,6 +44,8 @@ def run_simulation(
         model_file: Path to the model file (string or Path object).
         capture_output: Whether to capture and return the simulation output.
             If False, output will be printed directly to stdout.
+            Stderr is always captured internally so failures include
+            a useful error message.
 
     Returns:
         dict: A dictionary containing simulation results with keys:
@@ -61,11 +63,19 @@ def run_simulation(
 
     try:
         binary_path = get_binary_path()
+
+        run_kwargs = {
+            "check": False,
+            "text": True,
+            # Always capture stderr so raised exceptions include error details.
+            "stderr": subprocess.PIPE,
+        }
+        if capture_output:
+            run_kwargs["stdout"] = subprocess.PIPE
+
         result = subprocess.run(
             [binary_path, str(model_path)],
-            check=False,
-            text=True,
-            capture_output=capture_output,
+            **run_kwargs,
         )
 
         output = {
@@ -75,9 +85,12 @@ def run_simulation(
         }
 
         if not output["success"]:
+            error_text = (result.stderr or "").strip()
+            if not error_text:
+                error_text = "No stderr output captured."
             raise SeismicForwardError(
                 f"Seismic Forward failed with return code {result.returncode}\n"
-                f"Error message:\n {result.stderr}"
+                f"Error message:\n{error_text}"
             )
 
         return output

--- a/seismic_forward/tests/test_cli.py
+++ b/seismic_forward/tests/test_cli.py
@@ -13,10 +13,10 @@ def test_get_version():
 def test_version_flag(monkeypatch):
     """Test that --version flag outputs version information and exits."""
     monkeypatch.setattr(sys, "argv", ["seismic_forward", "--version"])
-    
+
     with pytest.raises(SystemExit) as exc_info:
         main()
-    
+
     # argparse's version action exits with code 0
     assert exc_info.value.code == 0
 
@@ -24,13 +24,13 @@ def test_version_flag(monkeypatch):
 def test_help_flag(monkeypatch, capsys):
     """Test that --help flag outputs help information and exits."""
     monkeypatch.setattr(sys, "argv", ["seismic_forward", "--help"])
-    
+
     with pytest.raises(SystemExit) as exc_info:
         main()
-    
+
     # argparse's help action exits with code 0
     assert exc_info.value.code == 0
-    
+
     # Check that help output contains expected information
     captured = capsys.readouterr()
     output = (captured.out + captured.err).lower()
@@ -40,13 +40,13 @@ def test_help_flag(monkeypatch, capsys):
 def test_no_arguments(monkeypatch, capsys):
     """Test that running without arguments shows help and error message."""
     monkeypatch.setattr(sys, "argv", ["seismic_forward"])
-    
+
     with pytest.raises(SystemExit) as exc_info:
         main()
-    
+
     # Should exit with error code 1
     assert exc_info.value.code == 1
-    
+
     # Check that help and error message is shown
     captured = capsys.readouterr()
     output = captured.out + captured.err
@@ -56,9 +56,9 @@ def test_no_arguments(monkeypatch, capsys):
 def test_nonexistent_modelfile(monkeypatch):
     """Test that providing a nonexistent file results in an error."""
     monkeypatch.setattr(sys, "argv", ["seismic_forward", "nonexistent_file.xml"])
-    
+
     with pytest.raises(SystemExit) as exc_info:
         main()
-    
+
     # Should exit with error code 1
     assert exc_info.value.code == 1

--- a/seismic_forward/tests/test_integration.py
+++ b/seismic_forward/tests/test_integration.py
@@ -1,8 +1,11 @@
 import shutil
 import gzip
+import subprocess
 from pathlib import Path
 import pytest
-from seismic_forward.simulation import run_simulation
+from seismic_forward import simulation
+from seismic_forward.simulation import run_simulation, SeismicForwardError
+
 
 def test_run_simulation(tmp_path, monkeypatch):
     # Copy required test files from data directory
@@ -22,8 +25,8 @@ def test_run_simulation(tmp_path, monkeypatch):
     shutil.copy2(timeshift_file, temp_timeshift_file)
 
     # Copy and decompress the gz file
-    with gzip.open(grid_file, 'rb') as f_in:
-        with open(temp_grid_file, 'wb') as f_out:
+    with gzip.open(grid_file, "rb") as f_in:
+        with open(temp_grid_file, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
 
     # Use monkeypatch to change directory
@@ -31,9 +34,9 @@ def test_run_simulation(tmp_path, monkeypatch):
 
     # Test successful simulation
     result = run_simulation(temp_model_file)
-    assert result['success'] is True
-    assert isinstance(result['output'], str)
-    assert isinstance(result['error'], str)
+    assert result["success"] is True
+    assert isinstance(result["output"], str)
+    assert isinstance(result["error"], str)
 
     # Test with non-existent file
     with pytest.raises(FileNotFoundError):
@@ -41,6 +44,34 @@ def test_run_simulation(tmp_path, monkeypatch):
 
     # Test with capture_output=False
     result = run_simulation(temp_model_file, capture_output=False)
-    assert result['success'] is True
-    assert result['output'] is None
-    assert result['error'] is None
+    assert result["success"] is True
+    assert result["output"] is None
+    assert result["error"] is None
+
+
+def test_run_simulation_failure_reports_stderr_with_capture_output_disabled(
+    tmp_path, monkeypatch
+):
+    model_file = tmp_path / "modelfile.xml"
+    model_file.write_text("<root />")
+
+    monkeypatch.setattr(simulation, "get_binary_path", lambda: "/fake/seismic_forward")
+
+    def fake_run(command, **kwargs):
+        assert kwargs["stderr"] == subprocess.PIPE
+        assert "stdout" not in kwargs
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=1,
+            stdout=None,
+            stderr="simulated failure stderr",
+        )
+
+    monkeypatch.setattr(simulation.subprocess, "run", fake_run)
+
+    with pytest.raises(SeismicForwardError) as exc_info:
+        run_simulation(model_file, capture_output=False)
+
+    message = str(exc_info.value)
+    assert "simulated failure stderr" in message
+    assert "None" not in message


### PR DESCRIPTION
Print full error message if the `seismic_forward` run fails.

Related to https://github.com/equinor/fmu-sim2seis/issues/99.